### PR TITLE
Added tab completion and history.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ endif
 	
 # Default Rule. It all starts here
 agros: $(OBJS)
-	$(CC) $(CFLAGS) `pkg-config --libs glib-2.0` -o agros $(OBJS)
+	$(CC) $(CFLAGS) -lreadline `pkg-config --libs glib-2.0` -o agros $(OBJS)
 	rm -f $(OBJS)
 	
 # Moves the executable to TARGETDIR if defined
@@ -38,9 +38,9 @@ main.o: agros.o include/agros.h
 	
 agros.o: src/agros.c include/agros.h
 ifdef SYSCONF
-	$(CC) $(CFLAGS) -c -I include/ `pkg-config --cflags glib-2.0` -DCONFIG_FILE=$(SYSCONF) src/agros.c
+	$(CC) $(CFLAGS) -c -I include/ -lreadline `pkg-config --cflags glib-2.0` -DCONFIG_FILE=$(SYSCONF) src/agros.c
 else
-	$(CC) $(CFLAGS) -c -I include/ `pkg-config --cflags glib-2.0` src/agros.c
+	$(CC) $(CFLAGS) -c -I include/ -lreadline `pkg-config --cflags glib-2.0` src/agros.c
 endif
 	
 # PHONY RULES

--- a/include/agros.h
+++ b/include/agros.h
@@ -91,7 +91,8 @@ struct config_t{
  */
 
 void    parse_command       (char *cmdline, command_t *cmd);
-int     read_input          (char* string, int num);
+void	get_prompt	    (char *prompt, int length, char *username);
+char*	read_input	    (char *prompt);
 void    print_prompt        (char* username);
 void    print_help          (config_t* config);
 void    change_directory    (char* path, int loglevel);
@@ -106,3 +107,8 @@ void    set_homedir         (char** homedir);
 void    decrease_warnings   (config_t* ag_config);
 int     runs_in_background  (command_t* cmd);
 /*void    set_glib_group      (char** glib_group, GKeyFile* gkf, char* username, char* key);*/
+void	initialize_readline (config_t *config);
+char*	make_completion	    (char *string);
+char**	cmd_completion	    (const char *text, int start, int end);
+char*	cmd_generator	    (const char *text, int state);
+

--- a/src/main.c
+++ b/src/main.c
@@ -32,10 +32,11 @@
 int main (){
     int pid = 0;
     command_t cmd = {NULL, 0, {NULL}};
-    char commandline[MAX_LINE_LEN];
+    char *commandline = (char *)NULL;
     char* username = NULL;
     config_t ag_config;
     int bg_cmd = AG_FALSE;
+    char prompt[MAX_LINE_LEN];
 
     /* Sets the username */
     set_username (&username);
@@ -45,6 +46,9 @@ int main (){
 
     /* Parses the config files for data */
     parse_config (&ag_config, username);
+
+    /* Initializes GNU Readline */
+    initialize_readline(&ag_config);
 
     /*
      *   Main loop:
@@ -59,9 +63,15 @@ int main (){
     }
 
     while (AG_TRUE){
+	/* Set the prompt */
+	get_prompt(prompt, MAX_LINE_LEN, username);
 
-        print_prompt(username);
-        read_input (commandline, MAX_LINE_LEN);
+	/* 
+	 * Read a line of input 
+	 * commandline should be deallocated with free() 
+	 */
+	commandline = read_input (prompt);
+
         parse_command (commandline, &cmd);
 
         switch (get_cmd_code (cmd.name)){
@@ -81,6 +91,8 @@ int main (){
    	            break;
 
             case EXIT_CMD:
+		free (commandline);
+		commandline = (char *)NULL;
                 closelog ();
    	            return 0;
 
@@ -112,8 +124,13 @@ int main (){
    	            }
    	            break;
         }
+
+	free (commandline);
+	commandline = (char *)NULL;
     }
 
+    if (commandline)
+	free (commandline);
     closelog();
     return 0;
 }


### PR DESCRIPTION
So this is about... 6 months late? Sorry!
I took your advice and went with GNU Readline.
The code is based on the last stable release of AGROS (v0.3.2).
Auto-completion will first check the shell's built-in functions (my_commands).
It will then check the list of allowed commands that's provided in the config.
Command history can be browsed with the up and down arrows.

Let me know if you find any bugs. I didn't try to integrate it with a later commit because
I'm not sure if those are stable, if you point me at one I can probably merge it with that.
